### PR TITLE
Nick/feature/merchant dashboard #Dashboard completed

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,4 +11,8 @@ class Item < ApplicationRecord
   def status(invoice)
     InvoiceItem.where(item_id: id, invoice_id: invoice).first.status
   end
+
+  def ordered_on_date
+    Invoice.find(self.invoice_id).date_conversion
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -34,5 +34,6 @@ class Merchant < ApplicationRecord
     .select('items.*, invoices.id as invoice_id')
     .joins(invoices: :transactions)
     .where('transactions.result = 1 and invoices.status in (1,2) and invoice_items.status = 1')
+    .order('created_at')
   end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -16,7 +16,9 @@
 
 <section class="items_ready_to_ship">
   <% @merchant.items_ready_to_ship.each do |item| %>
-    Item: <%= item.name %> Invoice: <%= link_to "#{item.invoice_id}", "/merchants/#{@merchant.id}/invoices/#{item.invoice_id}" %><%= item.invoice_id %><br>
+    <strong>Item:</strong> <%= item.name %> 
+    <strong>Date Created:</strong> <%= item.ordered_on_date %> 
+    <strong>Invoice:</strong> <%= link_to "#{item.invoice_id}", "/merchants/#{@merchant.id}/invoices/#{item.invoice_id}" %><br>
   <% end %>
 </section>
 

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -13,7 +13,7 @@
   <% end %>
   </ul>
 </section>
-
+<h3>Items Ready to ship</h3>
 <section class="items_ready_to_ship">
   <% @merchant.items_ready_to_ship.each do |item| %>
     <strong>Item:</strong> <%= item.name %> 

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -16,7 +16,7 @@
 
 <section class="items_ready_to_ship">
   <% @merchant.items_ready_to_ship.each do |item| %>
-    <li>Item: <%= item.name %> Invoice: <%= link_to "#{item.invoice_id}", "/merchants/#{@merchant.id}/invoices/#{item.invoice_id}" %></li>
+    Item: <%= item.name %> Invoice: <%= link_to "#{item.invoice_id}", "/merchants/#{@merchant.id}/invoices/#{item.invoice_id}" %><%= item.invoice_id %><br>
   <% end %>
 </section>
 

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -129,6 +129,21 @@ RSpec.describe "Merchant Dashboard", type: :feature do
           expect(page).to have_link href: "/merchants/#{@merchant_2.id}/invoices/#{@bouncer.invoices.first.id}"
         end
       end
+
+      it "In the section for items ready to ship, 
+      I see them ordered by oldest created to most recent formated (Day_name, Month day_number, year)" do
+
+        ordered_invoices = @merchant_2.invoices.order('created_at')
+
+        visit "merchants/#{@merchant_2.id}/dashboard"
+
+        invoice_1_index = page.body.index(ordered_invoices[0].id.to_s)
+        invoice_2_index = page.body.index(ordered_invoices[1].id.to_s)
+        invoice_3_index = page.body.index(ordered_invoices[2].id.to_s)
+
+        expect(invoice_1_index.to_i < invoice_2_index.to_i).to be_truthy
+        expect(invoice_2_index.to_i < invoice_3_index.to_i).to be_truthy
+      end
     end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Merchant Dashboard", type: :feature do
         visit "/merchants/#{@merchant_2.id}/dashboard"
 
         within(".items_ready_to_ship") do
-          expect(page).to have_content("Item: #{@bouncer.name} Invoice:")
+          expect(page).to have_content("#{@bouncer.name}")
           expect(page).to have_link href: "/merchants/#{@merchant_2.id}/invoices/#{@bouncer.invoices.first.id}"
         end
       end
@@ -136,6 +136,7 @@ RSpec.describe "Merchant Dashboard", type: :feature do
         ordered_invoices = @merchant_2.invoices.order('created_at')
 
         visit "merchants/#{@merchant_2.id}/dashboard"
+        save_and_open_page
 
         invoice_1_index = page.body.index(ordered_invoices[0].id.to_s)
         invoice_2_index = page.body.index(ordered_invoices[1].id.to_s)

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -136,7 +136,6 @@ RSpec.describe "Merchant Dashboard", type: :feature do
         ordered_invoices = @merchant_2.invoices.order('created_at')
 
         visit "merchants/#{@merchant_2.id}/dashboard"
-        save_and_open_page
 
         invoice_1_index = page.body.index(ordered_invoices[0].id.to_s)
         invoice_2_index = page.body.index(ordered_invoices[1].id.to_s)


### PR DESCRIPTION
This PR gets us completed up through US 5. Items ready to ship now orders by oldest created invoice first, and then newer invoices lower down the page. Date is formatted as expected in US 5 and displayed next to the name of each item ready to ship. I couldn't fully re-use Roberts date formatting method unfortunately, due to the fact that my item object on the dashboard show page only have the invoice_id, but not the whole invoice object. Built a method in Item model that looks up the invoice using item.invoice_id and then utilized roberts date formatting method.

### Type of Change

- [ ] **fix**
- [x] **feat**
- [x] **test**
- [ ] **refactor**
- [ ] **docs**

### Checklist

- [x] **Code has been self reviewed**
- [x] **Code runs without any errors**
- [x] **Thorough testing has been implemented if adding feature**
- [x] **All tests pass**
