### PR TITLE
Nick/feature/merchant invoices index US 16 + 17

### DIFF
--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -2,4 +2,8 @@ class MerchantInvoicesController < ApplicationController
   def index
     @merchant = Merchant.find(params[:id])
   end
+
+  def show
+    @invoice = Invoice.find(params[:id])
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -24,4 +24,8 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items.sum('quantity * unit_price')
   end
+
+  def invoice_item_selector(item)
+    InvoiceItem.where("invoice_id = #{self.id} and item_id = #{item.id}").first
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -12,6 +12,7 @@ class Merchant < ApplicationRecord
       .joins(:customer)
       .group('customers.id')
       .order('success_count desc')
+      .limit(5)
   end
 
   def top_5_customers_sql

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -9,3 +9,7 @@
     </section>
   <% end %>
 </section>
+<h3>Potential Revenue:</h3>
+<section class="revenue">
+  <p>Total revenue: <%= @invoice.total_revenue %></p>
+</section>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -6,6 +6,7 @@
       <li>Item name: <%= item.name %></li>
       <li>Quantity ordered: <%= @invoice.invoice_item_selector(item).quantity %></li>
       <li>Price: <%= @invoice.invoice_item_selector(item).unit_price %></li>
+      <hr />
     </section>
   <% end %>
 </section>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -1,0 +1,11 @@
+<h1>Invoice id: <%= @invoice.id %></h1>
+<h3>Items on this invoice:</h3>
+<section class="items_list">
+  <% @invoice.items.each do |item| %>
+    <section class="invoice_info">
+      <li>Item name: <%= item.name %></li>
+      <li>Quantity ordered: <%= @invoice.invoice_item_selector(item).quantity %></li>
+      <li>Price: <%= @invoice.invoice_item_selector(item).unit_price %></li>
+    </section>
+  <% end %>
+</section>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -6,6 +6,7 @@
       <li>Item name: <%= item.name %></li>
       <li>Quantity ordered: <%= @invoice.invoice_item_selector(item).quantity %></li>
       <li>Price: <%= @invoice.invoice_item_selector(item).unit_price %></li>
+      <li>Status: <%= @invoice.invoice_item_selector(item).status %></li>
       <hr />
     </section>
   <% end %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -16,9 +16,9 @@
 <h3>Items Ready to ship</h3>
 <section class="items_ready_to_ship">
   <% @merchant.items_ready_to_ship.each do |item| %>
-    <strong>Item:</strong> <%= item.name %> 
-    <strong>Date Created:</strong> <%= item.ordered_on_date %> 
-    <strong>Invoice:</strong> <%= link_to "#{item.invoice_id}", "/merchants/#{@merchant.id}/invoices/#{item.invoice_id}" %><br>
+    <p><strong>Item:</strong> <%= item.name %></p>
+    <p><strong>Date Created:</strong> <%= item.ordered_on_date %></p> 
+    <p><strong>Invoice:</strong> <%= link_to "#{item.invoice_id}", "/merchants/#{@merchant.id}/invoices/#{item.invoice_id}" %><br></p>
   <% end %>
 </section>
 

--- a/spec/features/merchants/merchants_invoices/show_spec.rb
+++ b/spec/features/merchants/merchants_invoices/show_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe "Merchant Invoices show", type: :feature do
 
         visit "/merchants/#{@merchant_2.id}/invoices/#{@invoice_1.id}"
 
-        save_and_open_page
-
         within(".invoice_info") do
           expect(page).to have_content("Item name: #{@spinner.name}")
           expect(page).to have_content("Quantity ordered: 20")

--- a/spec/features/merchants/merchants_invoices/show_spec.rb
+++ b/spec/features/merchants/merchants_invoices/show_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Merchant Invoices show", type: :feature do
           and I don't see invoices for any other merchants" do
 
         visit "/merchants/#{@merchant_2.id}/invoices/#{@invoice_1.id}"
-        save_and_open_page
+
         within(".invoice_info") do
           expect(page).to have_content("Item name: #{@spinner.name}")
           expect(page).to have_content("Quantity ordered: 20")

--- a/spec/features/merchants/merchants_invoices/show_spec.rb
+++ b/spec/features/merchants/merchants_invoices/show_spec.rb
@@ -27,11 +27,12 @@ RSpec.describe "Merchant Invoices show", type: :feature do
           and I don't see invoices for any other merchants" do
 
         visit "/merchants/#{@merchant_2.id}/invoices/#{@invoice_1.id}"
-
+        save_and_open_page
         within(".invoice_info") do
           expect(page).to have_content("Item name: #{@spinner.name}")
           expect(page).to have_content("Quantity ordered: 20")
           expect(page).to have_content('Price: 30')
+          expect(page).to have_content('Status: pending')
         end
       end
       

--- a/spec/features/merchants/merchants_invoices/show_spec.rb
+++ b/spec/features/merchants/merchants_invoices/show_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe "Merchant Invoices show", type: :feature do
           expect(page).to have_content('Price: 30')
         end
       end
+      
+      it "I see the total revenue that the invoice will generate" do
+
+        visit "/merchants/#{@merchant_2.id}/invoices/#{@invoice_1.id}"
+
+        within(".revenue") do
+          expect(page).to have_content("Total revenue: 600")
+        end
+      end
     end
   end
 end

--- a/spec/features/merchants/merchants_invoices/show_spec.rb
+++ b/spec/features/merchants/merchants_invoices/show_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Merchant Invoices show", type: :feature do
+  before(:each) do
+    @merchant_1 = Merchant.create!(name: "Geoff's Goodies")
+    @merchant_2 = Merchant.create!(name: "Bubba's Boutique")
+    @chochky = @merchant_1.items.create!(name: "chochky", description: "Useless", unit_price: 50)
+    @spinner = @merchant_2.items.create!(name: "Fidget Spinner", description: "Spins", unit_price: 1)
+    @bouncer = @merchant_2.items.create!(name: "Bouncy Ball", description: "bounces", unit_price: 2)
+
+    @cust_1 = Customer.create!(first_name: "Dave", last_name: "Beckam")
+    @cust_2 = Customer.create!(first_name: "Becky", last_name: "Beckam")
+
+    @invoice_1 = @cust_1.invoices.create!(status: 1)
+    InvoiceItem.create!(item_id: @spinner.id, invoice_id: @invoice_1.id, quantity: 20, status: 0, unit_price: 30)
+    @invoice_2 = @cust_2.invoices.create!(status: 1)
+    InvoiceItem.create!(item_id: @bouncer.id, invoice_id: @invoice_2.id, quantity: 30, status: 0, unit_price: 100)
+  end
+
+  describe "As a visitor" do
+    describe "When I visit /merchants/:merchant_id/invoices/:invoice_id" do
+      it "I see all of my items on the invoice including:
+          -Item name
+          -The quantity of the item ordered
+          -the price the imem solf for
+          -the invoice item status
+          and I don't see invoices for any other merchants" do
+
+        visit "/merchants/#{@merchant_2.id}/invoices/#{@invoice_1.id}"
+
+        save_and_open_page
+
+        within(".invoice_info") do
+          expect(page).to have_content("Item name: #{@spinner.name}")
+          expect(page).to have_content("Quantity ordered: 20")
+          expect(page).to have_content('Price: 30')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -137,10 +137,10 @@ RSpec.describe "Merchant Dashboard", type: :feature do
 
         visit "merchants/#{@merchant_2.id}/dashboard"
 
-        invoice_1_index = page.body.index(ordered_invoices[0].id.to_s)
-        invoice_2_index = page.body.index(ordered_invoices[1].id.to_s)
-        invoice_3_index = page.body.index(ordered_invoices[2].id.to_s)
-
+        invoice_1_index = page.body.index("invoices/#{ordered_invoices[0].id.to_s}")
+        invoice_2_index = page.body.index("invoices/#{ordered_invoices[1].id.to_s}")
+        invoice_3_index = page.body.index("invoices/#{ordered_invoices[2].id.to_s}")
+        
         expect(invoice_1_index.to_i < invoice_2_index.to_i).to be_truthy
         expect(invoice_2_index.to_i < invoice_3_index.to_i).to be_truthy
       end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe "Merchant Dashboard", type: :feature do
         invoice_1_index = page.body.index("invoices/#{ordered_invoices[0].id.to_s}")
         invoice_2_index = page.body.index("invoices/#{ordered_invoices[1].id.to_s}")
         invoice_3_index = page.body.index("invoices/#{ordered_invoices[2].id.to_s}")
-        
+
         expect(invoice_1_index.to_i < invoice_2_index.to_i).to be_truthy
         expect(invoice_2_index.to_i < invoice_3_index.to_i).to be_truthy
       end


### PR DESCRIPTION
## Description
Fix for orderly issue on merchants show page for Invoice ID's
Added limit back to #top_5_customers method that somehow slipped through
merchants/merchant_id/invoices/invoice_id show page to complete US 16, 17
method #invoice_item_selector to Invoice model to assist with display on US 16 + 17
Feature tests for US 16 and 17

### Type of Change

- [ ] **fix**
- [x] **feat**
- [x] **test**
- [ ] **refactor**
- [ ] **docs**

### Checklist

- [x] **Code has been self reviewed**
- [x] **Code runs without any errors**
- [x] **Thorough testing has been implemented if adding feature**
- [x] **All tests pass**
