### PR TITLE
US27 Admin Merchant Enable Disable

### DIFF
--- a/app/controllers/admin_merchants_controller.rb
+++ b/app/controllers/admin_merchants_controller.rb
@@ -14,18 +14,11 @@ class AdminMerchantsController < ApplicationController
   def update 
     @merchant = Merchant.find(params[:id])
     if @merchant.update(merchant_params)
-      if params[:name] != nil
-        flash.alert = "Successfully Updated!"
-      elsif params[:status] != nil
-        if params[:status] = 1
-          flash.alert = "Merchant is now enabled."
-        else 
-          flash.alert = "Merchant is now disabled."
-        end
-      else
-        render 'edit'
-      end
+      flash.alert = "Successfully Updated!"
       redirect_to "/admin/merchants/#{params[:id]}"
+    else
+      flash.alert = "Missing information"
+      render 'edit'
     end
   end
 

--- a/app/controllers/admin_merchants_controller.rb
+++ b/app/controllers/admin_merchants_controller.rb
@@ -14,16 +14,24 @@ class AdminMerchantsController < ApplicationController
   def update 
     @merchant = Merchant.find(params[:id])
     if @merchant.update(merchant_params)
-      flash.alert = "Successfully Updated!"
+      if params[:name] != nil
+        flash.alert = "Successfully Updated!"
+      elsif params[:status] != nil
+        if params[:status] = 1
+          flash.alert = "Merchant is now enabled."
+        else 
+          flash.alert = "Merchant is now disabled."
+        end
+      else
+        render 'edit'
+      end
       redirect_to "/admin/merchants/#{params[:id]}"
-    else
-      render 'edit'
     end
   end
 
   private
 
   def merchant_params
-    params.permit(:name)
+    params.permit(:name, :status)
   end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -2,4 +2,21 @@ class MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
-end
+
+  def update 
+    @merchant = Merchant.find(params[:id])
+    @merchant.update(merchant_params)
+    if @merchant.status == "enabled"
+      flash.alert = "Merchant is now enabled."
+    else 
+      flash.alert = "Merchant is now disabled."
+    end
+    redirect_to "/admin/merchants"
+  end
+
+  private
+
+  def merchant_params
+    params.permit(:name, :status)
+  end
+end       

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -4,6 +4,8 @@ class Merchant < ApplicationRecord
     enabled: 1
   }
   
+  validates_presence_of :name
+  
   has_many :items
   has_many :invoices, through: :items
   has_many :customers, through: :invoices

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,9 @@
 class Merchant < ApplicationRecord
+  enum status: {
+    disable: 0,
+    enable: 1
+  }
+  
   has_many :items
   has_many :invoices, through: :items
   has_many :customers, through: :invoices

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,7 +1,7 @@
 class Merchant < ApplicationRecord
   enum status: {
-    disable: 0,
-    enable: 1
+    disabled: 0,
+    enabled: 1
   }
   
   has_many :items

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -3,7 +3,14 @@
 <ul>
   <% @merchants.each do |merchant| %>
     <section id="merchant-index-<%=merchant.id%>">
-      <li><%= link_to merchant.name, "/admin/merchants/#{merchant.id}" %></li>
+      <li>
+        <%= link_to merchant.name, "/admin/merchants/#{merchant.id}" %></li>
+        <% if merchant.status.present? %>
+          <%= button_to "Disable", "/admin/merchants", method: :patch %>
+        <% else %>
+          <= button_to "Enable", "/admin/merchants", method: :patch %>
+        <% end %>
+      </li>
     </section>
   <% end %>
 </ul>

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -6,9 +6,9 @@
       <li>
         <%= link_to merchant.name, "/admin/merchants/#{merchant.id}" %></li>
         <% if merchant.status.present? %>
-          <%= button_to "Disable", "/admin/merchants", method: :patch %>
+          <%= button_to "Disable", "/admin/merchants/#{merchant.id}?status=disabled", method: :patch %>
         <% else %>
-          <= button_to "Enable", "/admin/merchants", method: :patch %>
+          <= button_to "Enable", "/admin/merchants#{merchant.id}?status=enabled", method: :patch %>
         <% end %>
       </li>
     </section>

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -5,11 +5,11 @@
     <section id="merchant-index-<%=merchant.id%>">
       <li>
         <%= link_to merchant.name, "/admin/merchants/#{merchant.id}" %></li>
-        <% if merchant.status.present? %>
-          <%= button_to "Disable", "/admin/merchants/#{merchant.id}?status=disabled", method: :patch %>
-        <% else %>
-          <= button_to "Enable", "/admin/merchants#{merchant.id}?status=enabled", method: :patch %>
-        <% end %>
+          <% if merchant.status == "enabled" %>
+            <%= button_to "Disable", "/merchants/#{merchant.id}?status=disabled", method: :patch, data: { turbo: false } %>
+          <% else %>
+            <%= button_to "Enable", "/merchants/#{merchant.id}?status=enabled", method: :patch, data: { turbo: false } %>
+          <% end %>
       </li>
     </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "/merchants/:merchant_id/items/:id", to: "merchant_items#show", as: :merchant_item
   get "/admin", to: "admin#index"
   get "/admin/merchants", to: "admin_merchants#index"
+  patch "/admin/merchants", to: "admin_merchants#update"
   get "/admin/merchants/:id", to: "admin_merchants#show"
   get "/admin/merchants/:id/edit", to: "admin_merchants#edit"
   patch "/admin/merchants/:id", to: "admin_merchants#update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  patch "/merchants/:id", to: "merchants#update"
   get '/merchants/:id/invoices/:id', to: 'merchants_invoices#show'
   get '/merchants/:id/dashboard', to: 'merchants#show'
   get "/merchants/:id/items", to: "merchant_items#index"
@@ -12,7 +13,6 @@ Rails.application.routes.draw do
   patch "/admin/merchants", to: "admin_merchants#update"
   get "/admin/merchants/:id", to: "admin_merchants#show"
   get "/admin/merchants/:id/edit", to: "admin_merchants#edit"
-  patch "/admin/merchants/:id", to: "admin_merchants#update"
   get "/admin/invoices", to: "admin_invoices#index"
   get "/admin/invoices/:id", to: "admin_invoices#show"
   patch "/admin/invoices/:id", to: "admin_invoices#update"

--- a/db/migrate/20230915211813_add_status_to_merchants.rb
+++ b/db/migrate/20230915211813_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merchants, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_11_230647) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_15_211813) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_230647) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin_merchants/index_spec.rb
+++ b/spec/features/admin_merchants/index_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "admin dashboard", type: :feature do
 
         visit "/admin/merchants"
 
-        within("#merchant-enable-disable-#{merchant1.id}") do 
+        within("#merchant-index-#{merchant1.id}") do 
           expect(page).to have_content(merchant1.name)
           expect(page).to have_button("Disable")
         end
@@ -88,12 +88,12 @@ RSpec.describe "admin dashboard", type: :feature do
         expect(current_path).to eq("/admin/merchants")
         expect(page).to have_content("Merchant is now disabled.")
 
-        within("#merchant-enable-disable-#{merchant1.id}") do 
+        within("#merchant-index-#{merchant1.id}") do 
           expect(page).to have_content(merchant1.name)
           expect(page).to have_button("Enable")
         end
 
-        click_button "Disable"
+        click_button "Enable"
 
         expect(current_path).to eq("/admin/merchants")
         expect(page).to have_content("Merchant is now enabled.") 

--- a/spec/features/admin_merchants/index_spec.rb
+++ b/spec/features/admin_merchants/index_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe "admin dashboard", type: :feature do
           expect(current_path).to eq("/admin/merchants/#{merchant2.id}")
         end
 
-
         visit "/admin/merchants"
 
         within("#merchant-index-#{merchant3.id}") do
@@ -70,6 +69,34 @@ RSpec.describe "admin dashboard", type: :feature do
 
           expect(current_path).to eq("/admin/merchants/#{merchant3.id}")
         end
+      end
+    end
+
+    describe "When I visit the /admin/merchants index page" do
+      it "Then next to each merchant name I see a button to disable or enable that merchant and then I am redirected back to the admin merchants index where I see that the merchant's status has changed." do
+        merchant1 = create(:merchant)
+
+        visit "/admin/merchants"
+
+        within("#merchant-enable-disable-#{merchant1.id}") do 
+          expect(page).to have_content(merchant1.name)
+          expect(page).to have_button("Disable")
+        end
+        
+        click_button "Disable"
+
+        expect(current_path).to eq("/admin/merchants")
+        expect(page).to have_content("Merchant is now disabled.")
+
+        within("#merchant-enable-disable-#{merchant1.id}") do 
+          expect(page).to have_content(merchant1.name)
+          expect(page).to have_button("Enable")
+        end
+
+        click_button "Disable"
+
+        expect(current_path).to eq("/admin/merchants")
+        expect(page).to have_content("Merchant is now enabled.") 
       end
     end
   end

--- a/spec/features/admin_merchants/index_spec.rb
+++ b/spec/features/admin_merchants/index_spec.rb
@@ -75,14 +75,14 @@ RSpec.describe "admin dashboard", type: :feature do
     describe "When I visit the /admin/merchants index page" do
       it "Then next to each merchant name I see a button to disable or enable that merchant and then I am redirected back to the admin merchants index where I see that the merchant's status has changed." do
         merchant1 = create(:merchant)
-
+  
         visit "/admin/merchants"
 
         within("#merchant-index-#{merchant1.id}") do 
           expect(page).to have_content(merchant1.name)
           expect(page).to have_button("Disable")
         end
-        
+
         click_button "Disable"
 
         expect(current_path).to eq("/admin/merchants")

--- a/spec/features/admin_merchants/index_spec.rb
+++ b/spec/features/admin_merchants/index_spec.rb
@@ -80,23 +80,23 @@ RSpec.describe "admin dashboard", type: :feature do
 
         within("#merchant-index-#{merchant1.id}") do 
           expect(page).to have_content(merchant1.name)
+          expect(page).to have_button("Enable")
+        end
+        
+        click_button "Enable"
+        
+        expect(current_path).to eq("/admin/merchants")
+        expect(page).to have_content("Merchant is now enabled.")
+      
+        within("#merchant-index-#{merchant1.id}") do 
+          expect(page).to have_content(merchant1.name)
           expect(page).to have_button("Disable")
         end
 
         click_button "Disable"
 
         expect(current_path).to eq("/admin/merchants")
-        expect(page).to have_content("Merchant is now disabled.")
-
-        within("#merchant-index-#{merchant1.id}") do 
-          expect(page).to have_content(merchant1.name)
-          expect(page).to have_button("Enable")
-        end
-
-        click_button "Enable"
-
-        expect(current_path).to eq("/admin/merchants")
-        expect(page).to have_content("Merchant is now enabled.") 
+        expect(page).to have_content("Merchant is now disabled.") 
       end
     end
   end


### PR DESCRIPTION
## Description
This PR includes functioning that allows a user to be able to `Enable` and `Disable` a merchant in the `AdminMerchants` index page. 

### Type of Change

- [ ] **fix**
- [x] **feat**
- [x] **test**
- [ ] **refactor**
- [ ] **docs**

### Checklist

- [x] **Code has been self reviewed**
- [x] **Code runs without any errors**
- [x] **Thorough testing has been implemented if adding feature**
- [x] **All tests pass**
